### PR TITLE
Bump xmldom and plist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -797,9 +797,9 @@
             "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
             "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
             "requires": {
-                "base64-js": "1.3.1",
-                "xmlbuilder": "9.0.7",
-                "xmldom": "0.1.27"
+                "base64-js": "^1.2.3",
+                "xmlbuilder": "^9.0.7",
+                "xmldom": "0.1.x"
             }
         },
         "properties-parser": {


### PR DESCRIPTION
Removes [xmldom](https://github.com/xmldom/xmldom). It's no longer used after updating ancestor dependency [plist](https://github.com/TooTallNate/node-plist). These dependencies need to be updated together.


Removes `xmldom`

Updates `plist` from 3.0.1 to 3.0.6
- [Release notes](https://github.com/TooTallNate/node-plist/releases)
- [Changelog](https://github.com/TooTallNate/plist.js/blob/master/History.md)
- [Commits](https://github.com/TooTallNate/node-plist/commits)

---
updated-dependencies:
- dependency-name: xmldom dependency-type: indirect
- dependency-name: plist dependency-type: indirect ...